### PR TITLE
add noodle box bag file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.pcd filter=lfs diff=lfs merge=lfs -text
+*.bag filter=lfs diff=lfs merge=lfs -text

--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,2 +1,2 @@
 [lfs]
-	fetchinclude = mds_home_setups/people/single_persons/*
+	fetchinclude = mds_home_setups/**/*

--- a/mds_home_setups/objects/table/noodle_box.bag
+++ b/mds_home_setups/objects/table/noodle_box.bag
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7fca0fa337ba31a92d25d0cc3bbfaef0209f41784a5603c7e7a76570c52a41a
+size 9839796


### PR DESCRIPTION
Fetch all object files under `mds_home_setups` instead of only people point clouds.